### PR TITLE
Fixed order of releases and name of pkgsrc

### DIFF
--- a/dasea/common/release_dataset.py
+++ b/dasea/common/release_dataset.py
@@ -43,8 +43,8 @@ def update_homepage(new_dataset_url):
 
         file_data["datasets"].insert(0, latest_release)
 
-        file.seek(0)
-        json.dump(file_data, file, indent=4)
+        fp.seek(0)
+        json.dump(file_data, fp, indent=4)
 
 
 def push_dataset_to_zenodo(dataset_path, sandbox=False, no_verify=False):

--- a/dasea/common/release_dataset.py
+++ b/dasea/common/release_dataset.py
@@ -34,17 +34,17 @@ def create_compressed_archive():
 
 
 def update_homepage(new_dataset_url):
-    filename = "homepage/datasets.json"
-    file = open(filename, "r+")
-    file_data = json.load(file)
-    print(file_data)
-
     latest_release = {"date": TODAY, "url": new_dataset_url}
 
-    file_data["datasets"].append(latest_release)
+    filename = "homepage/datasets.json"
+    with open(filename, "r+") as fp:
+        file_data = json.load(fp)
+        print(file_data)
 
-    file.seek(0)
-    json.dump(file_data, file, indent=4)
+        file_data["datasets"].insert(0, latest_release)
+
+        file.seek(0)
+        json.dump(file_data, file, indent=4)
 
 
 def push_dataset_to_zenodo(dataset_path, sandbox=False, no_verify=False):
@@ -68,7 +68,7 @@ def push_dataset_to_zenodo(dataset_path, sandbox=False, no_verify=False):
     params = {"access_token": zenodo_api_token}
 
     fileExists = os.path.exists(Path(dataset_path))
-    if (not fileExists):
+    if not fileExists:
         print(f"Cannot find file with path {dataset_path}", file=sys.stderr)
         sys.exit(1)
 

--- a/homepage/datasets.json
+++ b/homepage/datasets.json
@@ -66,29 +66,29 @@
       "url": "https://luarocks.org/"
     },
     {
+      "name": "pkgsrc",
+      "ecosystem": "NetBSD",
+      "url": "https://www.netbsd.org/docs/pkgsrc/"
+    },
+    {
       "name": "Ports",
       "ecosystem": "FreeBSD",
       "url": "https://www.freebsd.org/ports/"
     },
     {
       "name": "Ports",
-      "ecosystem": "NetBSD",
-      "url": "https://www.openbsd.org/faq/ports/ports.html"
-    },
-    {
-      "name": "Ports",
       "ecosystem": "OpenBSD",
-      "url": "https://wiki.netbsd.org/ports/"
+      "url": "https://www.openbsd.org/faq/ports/ports.html"
     }
   ],
   "datasets": [
     {
-      "date": "12-15-2021",
-      "url": "https://zenodo.org/record/5781670"
-    },
-    {
       "date": "03-18-2022",
       "url": "https://zenodo.org/record/6369420"
+    },
+    {
+      "date": "12-15-2021",
+      "url": "https://zenodo.org/record/5781670"
     }
   ]
 }

--- a/homepage/datasets.json
+++ b/homepage/datasets.json
@@ -51,7 +51,7 @@
       "url": "https://rubygems.org/"
     },
     {
-      "name": "PyPi",
+      "name": "PyPI",
       "ecosystem": "Python",
       "url": "https://pypi.org/"
     },


### PR DESCRIPTION
Releases on the homepage https://dasea-project.github.io/DASEA/ should be in reversed order so that it fits to the headline.

The name of the NetBSD package manager is `pkgsrc` and NetBSD ports are ports of the OS to various platforms not packages